### PR TITLE
Add arweave packing/mining specific methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ x64/
 Release/
 Debug/
 build/
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ src/instructions_portable.cpp
 src/reciprocal.c
 src/virtual_machine.cpp
 src/vm_compiled_light.cpp
-src/blake2/blake2b.c)
+src/blake2/blake2b.c
+src/arweave/randomx_long_with_entropy.cpp)
 
 if(NOT ARCH_ID)
   # allow cross compiling

--- a/src/arweave/randomx_long_with_entropy.cpp
+++ b/src/arweave/randomx_long_with_entropy.cpp
@@ -1,0 +1,125 @@
+#include <cassert>
+#include "randomx_long_with_entropy.h"
+#include "../vm_interpreted.hpp"
+#include "../vm_interpreted_light.hpp"
+#include "../vm_compiled.hpp"
+#include "../vm_compiled_light.hpp"
+#include "../blake2/blake2.h"
+// #include "feistel_msgsize_key_cipher.h"
+
+// NOTE. possible optimisation with outputEntropySize
+// can improve performance for less memcpy (has almost no impact because randomx is too long 99+%)
+
+extern "C" {
+	void randomx_calculate_hash_long(randomx_vm *machine, const unsigned char *input, const size_t inputSize, unsigned char *output, const int randomxProgramCount) {
+		assert(machine != nullptr);
+		assert(inputSize == 0 || input != nullptr);
+		assert(output != nullptr);
+		alignas(16) uint64_t tempHash[8];
+		int blakeResult = blake2b(tempHash, sizeof(tempHash), input, inputSize, nullptr, 0);
+		assert(blakeResult == 0);
+		machine->initScratchpad(&tempHash);
+		machine->resetRoundingMode();
+		for (int chain = 0; chain < randomxProgramCount - 1; ++chain) {
+			machine->run(&tempHash);
+			blakeResult = blake2b(tempHash, sizeof(tempHash), machine->getRegisterFile(), sizeof(randomx::RegisterFile), nullptr, 0);
+			assert(blakeResult == 0);
+		}
+		machine->run(&tempHash);
+		machine->getFinalResult(output, RANDOMX_HASH_SIZE);
+	}
+
+	void randomx_calculate_hash_long_with_entropy(randomx_vm *machine, const unsigned char *input, const size_t inputSize, unsigned char *output, unsigned char *outputEntropy, const int randomxProgramCount) {
+		assert(machine != nullptr);
+		assert(inputSize == 0 || input != nullptr);
+		assert(output != nullptr);
+		alignas(16) uint64_t tempHash[8];
+		int blakeResult = blake2b(tempHash, sizeof(tempHash), input, inputSize, nullptr, 0);
+		assert(blakeResult == 0);
+		machine->initScratchpad(&tempHash);
+		machine->resetRoundingMode();
+		for (int chain = 0; chain < randomxProgramCount - 1; ++chain) {
+			machine->run(&tempHash);
+			blakeResult = blake2b(tempHash, sizeof(tempHash), machine->getRegisterFile(), sizeof(randomx::RegisterFile), nullptr, 0);
+			assert(blakeResult == 0);
+		}
+		machine->run(&tempHash);
+		machine->getFinalResult(output, RANDOMX_HASH_SIZE);
+		memcpy(outputEntropy, machine->getScratchpad(), RANDOMX_ENTROPY_SIZE);
+	}
+
+const unsigned char *randomx_calculate_hash_long_with_entropy_get_entropy(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const int randomxProgramCount) {
+		assert(machine != nullptr);
+		assert(inputSize == 0 || input != nullptr);
+		alignas(16) uint64_t tempHash[8];
+		int blakeResult = blake2b(tempHash, sizeof(tempHash), input, inputSize, nullptr, 0);
+		assert(blakeResult == 0);
+		machine->initScratchpad(&tempHash);
+		machine->resetRoundingMode();
+		for (int chain = 0; chain < randomxProgramCount - 1; ++chain) {
+			machine->run(&tempHash);
+			blakeResult = blake2b(tempHash, sizeof(tempHash), machine->getRegisterFile(), sizeof(randomx::RegisterFile), nullptr, 0);
+			assert(blakeResult == 0);
+		}
+		machine->run(&tempHash);
+		unsigned char output[64];
+		machine->getFinalResult(output, RANDOMX_HASH_SIZE);
+		return (const unsigned char*)machine->getScratchpad();
+	}
+
+	void randomx_calculate_hash_long_with_entropy_first(randomx_vm* machine, const void* input, size_t inputSize) {
+		blake2b(machine->tempHash, sizeof(machine->tempHash), input, inputSize, nullptr, 0);
+		machine->initScratchpad(machine->tempHash);
+	}
+
+	void randomx_calculate_hash_long_with_entropy_next(randomx_vm* machine, const void* nextInput, size_t nextInputSize, void* output, void *outputEntropy, const int randomxProgramCount) {
+		machine->resetRoundingMode();
+		for (int chain = 0; chain < randomxProgramCount - 1; ++chain) {
+			machine->run(machine->tempHash);
+			blake2b(machine->tempHash, sizeof(machine->tempHash), machine->getRegisterFile(), sizeof(randomx::RegisterFile), nullptr, 0);
+		}
+		machine->run(machine->tempHash);
+
+		// Finish current hash and fill the scratchpad for the next hash at the same time
+		blake2b(machine->tempHash, sizeof(machine->tempHash), nextInput, nextInputSize, nullptr, 0);
+		memcpy(outputEntropy, machine->getScratchpad(), RANDOMX_ENTROPY_SIZE);
+		machine->hashAndFill(output, RANDOMX_HASH_SIZE, machine->tempHash);
+	}
+
+	void randomx_calculate_hash_long_with_entropy_last(randomx_vm* machine, void* output, void *outputEntropy, const int randomxProgramCount) {
+		machine->resetRoundingMode();
+		for (int chain = 0; chain < randomxProgramCount - 1; ++chain) {
+			machine->run(machine->tempHash);
+			blake2b(machine->tempHash, sizeof(machine->tempHash), machine->getRegisterFile(), sizeof(randomx::RegisterFile), nullptr, 0);
+		}
+		machine->run(machine->tempHash);
+		machine->getFinalResult(output, RANDOMX_HASH_SIZE);
+		memcpy(outputEntropy, machine->getScratchpad(), RANDOMX_ENTROPY_SIZE);
+	}
+
+	// feistel_encrypt accepts padded message with 2*FEISTEL_BLOCK_LENGTH = 64 bytes
+	RANDOMX_EXPORT void randomx_encrypt_chunk(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const unsigned char *inChunk, const size_t inChunkSize, unsigned char *outChunk, const int randomxProgramCount) {
+		assert(inChunkSize <= RANDOMX_ENTROPY_SIZE);
+		assert(inChunkSize % (2*FEISTEL_BLOCK_LENGTH) == 0);
+
+		const unsigned char* entropy = randomx_calculate_hash_long_with_entropy_get_entropy(machine, input, inputSize, randomxProgramCount);
+		// feistel_encrypt((const unsigned char*)inChunk, inChunkSize, outputEntropy, (unsigned char*)outChunk);
+		memcpy(outChunk, entropy, RANDOMX_ENTROPY_SIZE);
+	}
+
+	RANDOMX_EXPORT void randomx_decrypt_chunk(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const unsigned char *inChunk, const size_t inChunkSize, unsigned char *outChunk, const int randomxProgramCount) {
+		assert(inChunkSize <= RANDOMX_ENTROPY_SIZE);
+		assert(inChunkSize % (2*FEISTEL_BLOCK_LENGTH) == 0);
+
+		// const unsigned char *outputEntropy = randomx_calculate_hash_long_with_entropy_get_entropy(machine, input, inputSize, randomxProgramCount);
+
+		// feistel_decrypt((const unsigned char*)inChunk, inChunkSize, outputEntropy, (unsigned char*)outChunk);
+		outChunk = (unsigned char*) randomx_calculate_hash_long_with_entropy_get_entropy(machine, input, inputSize, randomxProgramCount);
+	}
+
+  RANDOMX_EXPORT void randomx_calculate_entropy(randomx_vm *machine, const unsigned char *input, const size_t inputSize,  const size_t outEntropySize, unsigned char *outEntropy, const int randomxProgramCount) {
+		assert(outEntropySize <= ScratchpadSize);
+		const unsigned char* entropy = randomx_calculate_hash_long_with_entropy_get_entropy(machine, input, inputSize, randomxProgramCount);
+		memcpy(outEntropy, entropy, outEntropySize);
+  }
+}

--- a/src/arweave/randomx_long_with_entropy.h
+++ b/src/arweave/randomx_long_with_entropy.h
@@ -1,0 +1,22 @@
+#include "../randomx.h"
+
+#define RANDOMX_ENTROPY_SIZE (256*1024)
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+RANDOMX_EXPORT void randomx_calculate_hash_long(randomx_vm *machine, const unsigned char *input, const size_t inputSize, unsigned char *output, const int randomxProgramCount);
+RANDOMX_EXPORT void randomx_calculate_hash_long_with_entropy(randomx_vm *machine, const unsigned char *input, const size_t inputSize, unsigned char *output, unsigned char *outputEntropy, const int randomxProgramCount);
+RANDOMX_EXPORT void randomx_calculate_hash_long_with_entropy_first(randomx_vm* machine, const void* input, size_t inputSize);
+RANDOMX_EXPORT void randomx_calculate_hash_long_with_entropy_next(randomx_vm* machine, const void* nextInput, size_t nextInputSize, void* output, void *outputEntropy, const int randomxProgramCount);
+RANDOMX_EXPORT void randomx_calculate_hash_long_with_entropy_last(randomx_vm* machine, void* output, void *outputEntropy, const int randomxProgramCount);
+
+RANDOMX_EXPORT void randomx_encrypt_chunk(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const unsigned char *inChunk, const size_t inChunkSize,  unsigned char *outChunk, const int randomxProgramCount);
+RANDOMX_EXPORT void randomx_decrypt_chunk(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const unsigned char *inChunk, const size_t outChunkSize, unsigned char *outChunk, const int randomxProgramCount);
+
+RANDOMX_EXPORT void randomx_calculate_entropy(randomx_vm *machine, const unsigned char *input, const size_t inputSize,  const size_t outEntropySize, unsigned char *outEntropy, const int randomxProgramCount);
+
+#if defined(__cplusplus)
+}
+#endif


### PR DESCRIPTION
These are the additional C++ methods invoked during Arweave mining that need rust bindings. Building them together in on C project makes more sense than creating two separate projects for one additional .cpp/.h file.