### PR TITLE
Expose Randomx Dataset Constants as build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,20 @@ endif()
 
 set(RANDOMX_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/src" CACHE STRING "RandomX Include path")
 
+# Define variables for custom preprocessor definitions with default values
+set(RANDOMX_ARGON_MEMORY "" CACHE STRING "Set the RANDOMX_ARGON_MEMORY value")
+set(RANDOMX_DATASET_BASE_SIZE "" CACHE STRING "Set the RANDOMX_DATASET_BASE_SIZE value")
+
 add_library(randomx ${randomx_sources})
+
+# Apply the custom preprocessor definitions only if they are set
+if(RANDOMX_ARGON_MEMORY)
+  target_compile_definitions(randomx PRIVATE RANDOMX_ARGON_MEMORY=${RANDOMX_ARGON_MEMORY})
+endif()
+
+if(RANDOMX_DATASET_BASE_SIZE)
+  target_compile_definitions(randomx PRIVATE RANDOMX_DATASET_BASE_SIZE=${RANDOMX_DATASET_BASE_SIZE})
+endif()
 
 if(TARGET generate-asm)
   add_dependencies(randomx generate-asm)

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -29,7 +29,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 //Cache size in KiB. Must be a power of 2.
+#ifndef RANDOMX_ARGON_MEMORY
 #define RANDOMX_ARGON_MEMORY       262144
+#endif
 
 //Number of Argon2d iterations for Cache initialization.
 #define RANDOMX_ARGON_ITERATIONS   3
@@ -47,7 +49,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define RANDOMX_SUPERSCALAR_LATENCY   170
 
 //Dataset base size in bytes. Must be a power of 2.
+#ifndef RANDOMX_DATASET_BASE_SIZE
 #define RANDOMX_DATASET_BASE_SIZE  536870912 // 2^29 = 512 Mi (bytes), tweaked for Arweave
+#endif
 
 //Dataset extra size. Must be divisible by 64.
 #define RANDOMX_DATASET_EXTRA_SIZE 31563008 // 493172 (just an arbitrary number) * 64, tweaked for Arweave


### PR DESCRIPTION
Allow RANDOMX_DATASET_BASE_SIZE and RANDOMX_ARGON_MEMORY to be overridden using -D build flags